### PR TITLE
fix: whatever braking change in onebox

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,6 +4,10 @@
 # authors: MuZhou233
 # url: https://github.com/MuZhou233/discourse-onebox-bilibili
 
+require_relative "../../lib/onebox"
+
+Onebox = Onebox
+
 class Onebox::Engine::BilibiliOnebox
   include Onebox::Engine
 


### PR DESCRIPTION
It seems that there is a breaking change in 2.8.0: [Upgrade 2.7.0.beta8 -> 2.8.0.beta2 failed, rebuild failed](https://meta.discourse.org/t/upgrade-2-7-0-beta8-2-8-0-beta2-failed-rebuild-failed/194636), and this commit fixes it. See also: mrloop/garmin_connect_onebox#2

Disclaimer: I'm totally new to Ruby, so even myself doesn't know what exactly I'm doing.